### PR TITLE
Update the default value of kwargs_losses to a empty dict

### DIFF
--- a/devitofwi/fwi/acoustic.py
+++ b/devitofwi/fwi/acoustic.py
@@ -80,7 +80,7 @@ class AcousticFWI2D():
                  space_order=4, nbl=20,
                  firstscaling=True, lossop=None, postprocess=None, convertvp=None,
                  frequencies=None, nfilts=None, nfft=2**10, wavpad=700,
-                 kwargs_loss=None,
+                 kwargs_loss={},
                  solver='L-BFGS-B', kwargs_solver=None,  
                  callback=None):
 


### PR DESCRIPTION
Hello, my name is Gustavo Coelho, and I work with Peterson Nogueira at Senai Cimatec in the HPC area, focusing on Geophysics.

First of all, I would like to thank you for the tool; it has been very useful for us.

This PR aims to fix a potential bug in the tool. When running the Jupyter notebook AcousticVel_L2_1stagewrapper.ipynb, the following error occurs:

**'argument after ** must be a mapping, not NoneType'**

If this is indeed considered a bug, I hope the proposed change here can help resolve it.