### PR TITLE
Make torch and tslearn optional and protect imports

### DIFF
--- a/devitofwi/loss/dtw.py
+++ b/devitofwi/loss/dtw.py
@@ -1,9 +1,14 @@
-__all__ = ["SoftDTW"]
+__all__ = ["SoftDTW", ]
 
-import torch
 
 from pylops import TorchOperator
-from tslearn.metrics import SoftDTWLossPyTorch
+
+try:
+    import torch
+    from tslearn.metrics import SoftDTWLossPyTorch
+except:
+    print('torch and/or tslearn not available, install them '
+          'to be able to use SoftDTW...')
 
 
 class SoftDTW():
@@ -34,7 +39,6 @@ class SoftDTW():
     device : :obj:`str`, optional
         The device to compute the loss on, typically 'cpu' or 'cuda' for GPU acceleration. Defaults to 'cpu'.
 
-    
     """
 
     def __init__(self, Op, b, nr, nt, gamma, normalize=False, t_sub=1, device='cpu'):

--- a/devitofwi/loss/l2.py
+++ b/devitofwi/loss/l2.py
@@ -3,10 +3,16 @@ __all__ = ["L2",
            ]
 
 import numpy as np
-import torch
 from pylops import TorchOperator
 
 from devitofwi.nonlinear import NonlinearOperator
+
+
+try:
+    import torch
+except:
+    print('torch not available, install it '
+          'to be able to use L2Torch...')
 
 
 class L2(NonlinearOperator):

--- a/devitofwi/loss/xcorr.py
+++ b/devitofwi/loss/xcorr.py
@@ -1,12 +1,12 @@
-__all__ = ["XCorrTorch"]
+__all__ = ["XCorrTorch", ]
 
-import numpy as np
-import torch
-from scipy.linalg import cho_factor, cho_solve
-from scipy.sparse.linalg import lsqr as sp_lsqr
-from pylops import MatrixMult, Identity, TorchOperator
-from pylops.optimization.basic import lsqr
-from pylops.utils.backend import get_array_module, get_module_name
+
+try:
+    import torch
+    from pylops import TorchOperator
+except:
+    print('torch not available, install it '
+          'to be able to use L2Torch...')
 
 
 class XCorrTorch():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,15 @@ dependencies = [
         "matplotlib",
         "devito",
         "pylops >= 2.0.0",
-	"tqdm",
-        "torch",
-        "tslearn",
+        "tqdm",
     ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+deep = [
+    "torch",
+    "tslearn",
+]
 mpi = [
     "mpi4py",
 ]


### PR DESCRIPTION
This PR aims to reduce the mandatory dependencies of `devitofwi`. More specifically `torch` and `tslearn` are now optional dependencies.